### PR TITLE
Add secure Dgraph client

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,26 @@ a macro to do so.
 The following code snippet shows just one connection.
 
 ```rust
-  let dgraph = make_dgraph!(dgraph::new_dgraph_client("localhost:9080"));
+let dgraph = make_dgraph!(dgraph::new_dgraph_client("localhost:9080"));
+```
+
+Alternatively, secure client can be used:
+
+```rust
+fn open_cert_file(path: &str) -> Vec<u8> {
+  ...
+}
+
+let root_ca = open_cert_file("./tls/ca.crt");
+let cert = open_cert_file("./tls/client.user.crt");
+let private_key = open_cert_file("./tls/client.user.key");
+
+let dgraph = make_dgraph!(dgraph::new_secure_dgraph_client(
+    "localhost:9080",
+    root_ca,
+    cert,
+    private_key
+));
 ```
 
 ### Alter the database
@@ -108,7 +127,7 @@ let mut mu = dgraph::Mutation {
 let assigned = txn.mutate(mu).expect("failed to create data");
 ```
 
-For a more complete example, see the simple example [simple](https://github.com/Swoorup/dgraph-rs/blob/master/examples/simple/main.rs).
+For a more complete example, see the simple example [simple](https://github.com/Swoorup/dgraph-rs/blob/master/examples/simple/main.rs) (or [the same example with secure client](https://github.com/Swoorup/dgraph-rs/blob/master/examples/tls/main.rs)).
 
 Sometimes, you only want to commit a mutation, without querying anything further.
 In such cases, you can use `mu.commit_now = true` to indicate that the

--- a/examples/tls/README.md
+++ b/examples/tls/README.md
@@ -1,0 +1,106 @@
+# Mutual TLS example project
+
+Project demonstrating the use of `dgraph-rs` and Dgraph set up with client-server
+mutual TLS. The following guide shows how to set up a single-group two-node
+cluster (1 Dgraph Zero and 1 Dgraph Alpha) configured with mutual TLS.
+
+## Running
+
+### Install Dgraph
+
+You will need to [install Dgraph v1.0.10 or
+above](https://docs.dgraph.io/get-started/#step-1-install-dgraph).
+
+A quick-start installation script is available for Linux and Mac:
+
+```sh
+curl -sSf https://get.dgraph.io | bash
+```
+
+### Create TLS certificates
+
+Dgraph provides a `dgraph cert` tool to create and manage self-signed
+server and client certificates using a generated Dgraph Root CA. See the [TLS
+documentation](https://docs.dgraph.io/deploy/#tls-configuration) for more
+information.
+
+Create the root CA. All certificates and keys are created in the `tls` directory.
+
+```sh
+dgraph cert
+```
+
+Now create the Alpha server certificate (`node.crt`) and key (`node.key`) and client
+certificate (`client.user.crt`) key (`client.user.key`).
+
+```sh
+dgraph cert -n localhost
+```
+
+```sh
+dgraph cert -c user
+```
+
+The following files should now be in the `tls` directory:
+
+```sh
+$ ls tls
+ca.crt  ca.key  client.user.crt  client.user.key  node.crt  node.key
+```
+
+Using `dgraph cert ls` provides more details about each file. For instance, it
+shows that the `node.crt` is valid only for the host named `localhost` and the
+corresponding file permissions.
+
+```sh
+$ dgraph cert ls
+-rw-r--r-- ca.crt - Dgraph Root CA certificate
+    Issuer: Dgraph Labs, Inc.
+       S/N: 3dfb9c54929d703b
+Expiration: 19 Feb 29 00:57 UTC
+  MD5 hash: C82CF5D4C344668E34A61D590D6A4B77
+
+-r-------- ca.key - Dgraph Root CA key
+  MD5 hash: C82CF5D4C344668E34A61D590D6A4B77
+
+-rw-r--r-- client.user.crt - Dgraph client certificate: user
+    Issuer: Dgraph Labs, Inc.
+ CA Verify: PASSED
+       S/N: 5991417e75ba14c7
+Expiration: 21 Feb 24 01:04 UTC
+  MD5 hash: BA35D4ABD8DFF1ED137E8D8E5D921D06
+
+-rw------- client.user.key - Dgraph Client key
+  MD5 hash: BA35D4ABD8DFF1ED137E8D8E5D921D06
+
+-rw-r--r-- node.crt - Dgraph Node certificate
+    Issuer: Dgraph Labs, Inc.
+ CA Verify: PASSED
+       S/N: 51d53048b6845d8c
+Expiration: 21 Feb 24 01:00 UTC
+     Hosts: localhost
+  MD5 hash: 5D71F59AAEE294F1CFDA9E3232761018
+
+-rw------- node.key - Dgraph Node key
+  MD5 hash: 5D71F59AAEE294F1CFDA9E3232761018
+```
+
+### Start Dgraph cluster
+
+Start Dgraph Zero:
+
+```sh
+dgraph zero
+```
+
+Start Dgraph Alpha with TLS options. `REQUIREANDVERIFY` sets mutual TLS (server authentication and client authentication):
+
+```sh
+dgraph alpha --lru_mb=1024 --zero=localhost:5080 --tls_dir=./tls --tls_client_auth=REQUIREANDVERIFY
+```
+
+### Run example
+
+```sh
+cargo run --example tls
+```

--- a/examples/tls/main.rs
+++ b/examples/tls/main.rs
@@ -1,0 +1,203 @@
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::prelude::*;
+use std::io::BufReader;
+
+use chrono::prelude::*;
+use dgraph::{make_dgraph, Dgraph};
+use serde_derive::{Deserialize, Serialize};
+use slog::{slog_info, slog_o, Drain};
+use slog_scope::info;
+
+#[derive(Serialize, Deserialize, Default, Debug)]
+pub struct Root {
+    pub me: Vec<Person>,
+}
+
+#[derive(Serialize, Deserialize, Default, Debug)]
+pub struct School {
+    pub name: String,
+}
+
+#[derive(Serialize, Deserialize, Default, Debug)]
+pub struct Location {
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub coordinates: Vec<f64>,
+}
+
+#[derive(Serialize, Deserialize, Default, Debug)]
+pub struct Person {
+    pub name: String,
+    pub age: Option<u8>,
+    pub dob: Option<DateTime<Utc>>,
+    pub married: Option<bool>,
+    pub friend: Option<Vec<Person>>,
+    pub loc: Option<Location>,
+    pub school: Option<Vec<School>>,
+}
+
+fn drop_all(dgraph: &Dgraph) {
+    let op_cleanup = dgraph::Operation {
+        drop_all: true,
+        ..Default::default()
+    };
+
+    dgraph.alter(&op_cleanup).expect("drop schema");
+}
+
+fn set_schema(dgraph: &Dgraph) {
+    let op_schema = dgraph::Operation {
+        schema: r#"
+            name: string @index(exact) .
+            age: int .
+            married: bool .
+            loc: geo .
+            dob: datetime .
+        "#
+        .to_string(),
+        ..Default::default()
+    };
+
+    dgraph.alter(&op_schema).expect("set schema");
+}
+
+fn create_data(dgraph: &Dgraph) {
+    let mut txn = dgraph.new_txn();
+
+    let dob = Utc.ymd(1980, 1, 1).and_hms(23, 0, 0);
+    // While setting an object if a struct has a Uid then its properties in the graph are updated
+    // else a new node is created.
+    // In the example below new nodes for Alice, Bob and Charlie and school are created (since they
+    // dont have a Uid).
+    let p = Person {
+        name: "Alice".to_string(),
+        age: Some(26),
+        married: Some(true),
+        loc: Some(Location {
+            kind: "Point".to_string(),
+            coordinates: vec![1.1f64, 2f64],
+        }),
+        dob: Some(dob),
+        friend: Some(vec![
+            Person {
+                name: "Bob".to_string(),
+                age: Some(24),
+                ..Default::default()
+            },
+            Person {
+                name: "Charlie".to_string(),
+                age: Some(29),
+                ..Default::default()
+            },
+        ]),
+        school: Some(vec![School {
+            name: "Crown Public School".to_string(),
+        }]),
+    };
+
+    // Run mutation
+    let mut mutation = dgraph::Mutation::new();
+    mutation.set_set_json(serde_json::to_vec(&p).expect("invalid json"));
+    let assigned = txn.mutate(mutation).expect("failed to create data");
+
+    // Commit transaction
+    txn.commit().expect("Fail to commit mutation");
+
+    // Get uid of the outermost object (person named "Alice").
+    // Assigned#getUidsMap() returns a map from blank node names to uids.
+    // For a json mutation, blank node names "blank-0", "blank-1", ... are used
+    // for all the created nodes.
+    info!(
+        "Created person named 'Alice' with uid = {}",
+        assigned.uids["blank-0"]
+    );
+
+    info!("All created nodes (map from blank node names to uids):");
+    for (key, val) in assigned.uids.iter() {
+        info!("\t{} => {}", key, val);
+    }
+}
+
+fn query_data(dgraph: &Dgraph) {
+    let query = r#"query all($a: string){
+        me(func: eq(name, $a)) {
+            name
+            age
+            married
+            loc
+            dob
+            friend {
+                name
+                age
+            }
+            school {
+                name
+            }
+        }
+    }"#
+    .to_string();
+
+    let mut vars = HashMap::new();
+    vars.insert("$a".to_string(), "Alice".to_string());
+
+    let resp = dgraph
+        .new_readonly_txn()
+        .query_with_vars(query, vars)
+        .expect("query");
+    let root: Root = serde_json::from_slice(&resp.json).expect("parsing");
+    info!("Root: {:#?}", root);
+}
+
+fn open_cert_file(path: &str) -> Vec<u8> {
+    if let Result::Ok(file) = File::open(path) {
+        let mut reader = BufReader::new(file);
+        let mut contents = String::new();
+        reader
+            .read_to_string(&mut contents)
+            .expect(&format!("Read contents of file {} into string.", path));
+
+        contents.into_bytes()
+    } else {
+        panic!("File {} not found!", path);
+    }
+}
+
+fn run_example() {
+    info!("connect to dgraph via grpc at localhost:9080");
+
+    let root_ca = open_cert_file("./tls/ca.crt");
+    let cert = open_cert_file("./tls/client.user.crt");
+    let private_key = open_cert_file("./tls/client.user.key");
+
+    let dgraph = make_dgraph!(dgraph::new_secure_dgraph_client(
+        "localhost:9080",
+        root_ca,
+        cert,
+        private_key
+    ));
+
+    info!("dropping all schema");
+    drop_all(&dgraph);
+
+    info!("setup schema");
+    set_schema(&dgraph);
+
+    info!("push data");
+    create_data(&dgraph);
+
+    info!("query");
+    query_data(&dgraph);
+}
+
+fn main() {
+    let plain = slog_term::PlainSyncDecorator::new(std::io::stdout());
+    let log = slog::Logger::root(slog_term::FullFormat::new(plain).build().fuse(), slog_o!());
+
+    // Make sure to save the guard, see documentation for more information
+    let _guard = slog_scope::set_global_logger(log);
+    slog_scope::scope(
+        &slog_scope::logger().new(slog_o!("scope" => "1")),
+        run_example,
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,31 @@
 #![allow(unused_variables)]
 
-
+mod client;
 mod protos;
 mod txn;
-mod client;
 
-use grpcio::{ChannelBuilder, EnvBuilder};
+use grpcio::{ChannelBuilder, ChannelCredentialsBuilder, EnvBuilder};
 use std::sync::Arc;
 
-pub use protos::api_grpc::*;
-pub use protos::api::*;
-pub use txn::Txn;
 pub use client::Dgraph;
+pub use protos::api::*;
+pub use protos::api_grpc::*;
+pub use txn::Txn;
+
+pub fn new_secure_dgraph_client(
+    addr: &str,
+    root_ca: Vec<u8>,
+    cert: Vec<u8>,
+    private_key: Vec<u8>,
+) -> DgraphClient {
+    let env = Arc::new(EnvBuilder::new().build());
+    let credentials = ChannelCredentialsBuilder::new()
+        .root_cert(root_ca)
+        .cert(cert, private_key)
+        .build();
+    let channel = ChannelBuilder::new(env).secure_connect(addr, credentials);
+    DgraphClient::new(channel)
+}
 
 pub fn new_dgraph_client(addr: &str) -> DgraphClient {
     let env = Arc::new(EnvBuilder::new().build());


### PR DESCRIPTION
This is only a draft PR. Since I'm not sure about final API, there are no docs or examples yet.

Is another way of creating a secure client (`new_secure_dgraph_client`) OK or would it be preferable to add TLS options as optional argument to `new_dgraph_client` (as `Option<TLSConfig>` where `TLSConfig` would be struct with keys)? I'm not sure which one is more idiomatic in Rust.

I also noticed that files aren't formatted using `cargo fmt`. Should I format them in some future PR or you don't prefer it?