### PR TITLE
Replace failure with custom native errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ edition = "2018"
 grpcio = "0.4.3"
 futures = "0.1.25"
 protobuf = "2.3.0"
-failure = "0.1.5"
 rand = "0.6.5"
 protoc-grpcio = { version = "1.0.1", optional = true }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,7 @@
-use failure::Error;
 use rand::prelude::*;
 use std::sync::Mutex;
 
+use crate::errors::DgraphError;
 use crate::protos::api;
 use crate::protos::api_grpc;
 use crate::txn::Txn;
@@ -26,7 +26,7 @@ impl Dgraph {
         }
     }
 
-    pub fn login(&self, userid: String, password: String) -> Result<api::Response, Error> {
+    pub fn login(&self, userid: String, password: String) -> Result<api::Response, DgraphError> {
         let _guard = self
             .jwt
             .lock()
@@ -44,11 +44,15 @@ impl Dgraph {
         unimplemented!()
     }
 
-    pub fn retry_login(&self, userid: String, password: String) -> Result<api::Response, Error> {
+    pub fn retry_login(
+        &self,
+        userid: String,
+        password: String,
+    ) -> Result<api::Response, DgraphError> {
         unimplemented!()
     }
 
-    pub fn alter(&self, op: &api::Operation) -> Result<api::Payload, Error> {
+    pub fn alter(&self, op: &api::Operation) -> Result<api::Payload, DgraphError> {
         let dc = self.any_client().expect("Cannot alter. No client present");
         let res = dc.alter(op)?;
         Ok(res)

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,52 @@
+use std::error::Error;
+use std::fmt;
+
+/// The error type for Dgraph operations.
+///
+/// Native gRPC errors are wrapped into `GrpcError`.
+#[derive(Debug)]
+pub enum DgraphError {
+    TxnReadOnly,
+    TxnFinished,
+    EmptyTxn,
+    MissingTxnContext,
+    WriteTxnBestEffort,
+    StartTsMismatch,
+    GrpcError(grpcio::Error),
+}
+
+impl Error for DgraphError {
+    fn cause(&self) -> Option<&dyn Error> {
+        match self {
+            DgraphError::GrpcError(grpc_error) => Some(grpc_error),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for DgraphError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            DgraphError::TxnFinished => {
+                write!(f, "Transaction has already been committed or discarded")
+            }
+            DgraphError::TxnReadOnly => write!(
+                f,
+                "Readonly transaction cannot run mutations or be committed"
+            ),
+            DgraphError::WriteTxnBestEffort => {
+                write!(f, "Best effort only works for read-only queries")
+            }
+            DgraphError::EmptyTxn => write!(f, "Got empty Txn response back from query"),
+            DgraphError::MissingTxnContext => write!(f, "Missing Txn context on mutation response"),
+            DgraphError::StartTsMismatch => write!(f, "StartTs mismatch"),
+            DgraphError::GrpcError(ref grpc_error) => write!(f, "Grpc error: {}", grpc_error),
+        }
+    }
+}
+
+impl From<grpcio::Error> for DgraphError {
+    fn from(err: grpcio::Error) -> Self {
+        DgraphError::GrpcError(err)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(unused_variables)]
 
 mod client;
+mod errors;
 mod protos;
 mod txn;
 
@@ -10,6 +11,7 @@ use std::sync::Arc;
 pub use grpcio;
 
 pub use client::Dgraph;
+pub use errors::DgraphError;
 pub use protos::api::*;
 pub use protos::api_grpc::*;
 pub use txn::Txn;

--- a/src/txn.rs
+++ b/src/txn.rs
@@ -1,6 +1,6 @@
-use failure::{bail, Error};
 use std::collections::HashMap;
 
+use crate::errors::DgraphError;
 use crate::protos::api;
 use crate::protos::api_grpc;
 
@@ -26,15 +26,15 @@ impl Txn<'_> {
     // Dgraph Alpha to try to get timestamps from memory in a best effort to reduce the number of
     // outbound requests to Zero. This may yield improved latencies in read-bound datasets.
     // Returns the transaction itself.
-    pub fn best_effort(&mut self) -> Result<&Txn, Error> {
+    pub fn best_effort(&mut self) -> Result<&Txn, DgraphError> {
         if !self.read_only {
-            bail!("Best effort only works for read-only queries")
+            return Err(DgraphError::WriteTxnBestEffort);
         }
         self.best_effort = true;
         Ok(self)
     }
 
-    pub fn query(&mut self, query: impl Into<String>) -> Result<api::Response, Error> {
+    pub fn query(&mut self, query: impl Into<String>) -> Result<api::Response, DgraphError> {
         self.query_with_vars(query, HashMap::new())
     }
 
@@ -42,9 +42,9 @@ impl Txn<'_> {
         &mut self,
         query: impl Into<String>,
         vars: HashMap<String, String>,
-    ) -> Result<api::Response, Error> {
+    ) -> Result<api::Response, DgraphError> {
         if self.finished {
-            bail!("Transaction has already been committed or discarded");
+            return Err(DgraphError::TxnFinished);
         }
 
         let res = self.client.query(&api::Request {
@@ -57,7 +57,7 @@ impl Txn<'_> {
 
         let txn = match res.txn.as_ref() {
             Some(txn) => txn,
-            None => bail!("Got empty Txn response back from query"),
+            None => return Err(DgraphError::EmptyTxn),
         };
 
         self.merge_context(txn)?;
@@ -65,10 +65,10 @@ impl Txn<'_> {
         Ok(res)
     }
 
-    pub fn mutate(&mut self, mut mu: api::Mutation) -> Result<api::Assigned, Error> {
+    pub fn mutate(&mut self, mut mu: api::Mutation) -> Result<api::Assigned, DgraphError> {
         match (self.finished, self.read_only) {
-            (true, _) => bail!("Txn is finished"),
-            (_, true) => bail!("Txn is read only"),
+            (true, _) => return Err(DgraphError::TxnFinished),
+            (_, true) => return Err(DgraphError::TxnReadOnly),
             _ => (),
         }
 
@@ -81,7 +81,7 @@ impl Txn<'_> {
             Ok(mu_res) => mu_res,
             Err(e) => {
                 let _ = self.discard();
-                bail!(e);
+                return Err(DgraphError::GrpcError(e));
             }
         };
 
@@ -92,7 +92,7 @@ impl Txn<'_> {
         {
             let context = match mu_res.context.as_ref() {
                 Some(context) => context,
-                None => bail!("Missing Txn context on mutation response"),
+                None => return Err(DgraphError::MissingTxnContext),
             };
 
             self.merge_context(context)?;
@@ -101,22 +101,22 @@ impl Txn<'_> {
         Ok(mu_res)
     }
 
-    pub fn commit(mut self) -> Result<(), Error> {
+    pub fn commit(mut self) -> Result<(), DgraphError> {
         match (self.finished, self.read_only) {
-            (true, _) => bail!("Txn is finished"),
-            (_, true) => bail!("Txn is read only"),
+            (true, _) => return Err(DgraphError::TxnFinished),
+            (_, true) => return Err(DgraphError::TxnReadOnly),
             _ => (),
         }
 
         self.commit_or_abort()
     }
 
-    pub fn discard(&mut self) -> Result<(), Error> {
+    pub fn discard(&mut self) -> Result<(), DgraphError> {
         self.context.aborted = true;
         self.commit_or_abort()
     }
 
-    fn commit_or_abort(&mut self) -> Result<(), Error> {
+    fn commit_or_abort(&mut self) -> Result<(), DgraphError> {
         if self.finished {
             return Ok(());
         }
@@ -131,13 +131,13 @@ impl Txn<'_> {
         Ok(())
     }
 
-    fn merge_context(&mut self, src: &api::TxnContext) -> Result<(), Error> {
+    fn merge_context(&mut self, src: &api::TxnContext) -> Result<(), DgraphError> {
         if self.context.start_ts == 0 {
             self.context.start_ts = src.start_ts;
         }
 
         if self.context.start_ts != src.start_ts {
-            bail!("self.context.start_ts != src.start_ts")
+            return Err(DgraphError::StartTsMismatch);
         }
 
         for key in src.keys.iter() {


### PR DESCRIPTION
As discussed in #4 this patch removes `failure` crate and replaces all errors with native ones.

This is a breaking change and should be released in a new minor version.